### PR TITLE
상품 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/example/ourPick/controller/HomeController.java
+++ b/src/main/java/com/example/ourPick/controller/HomeController.java
@@ -3,6 +3,7 @@ package com.example.ourPick.controller;
 import com.example.ourPick.dto.ItemResponse;
 import com.example.ourPick.service.ItemService;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -24,16 +25,9 @@ public class HomeController {
 
   @GetMapping("/{itemId}")
   public String getItem(Model model, @PathVariable Integer itemId) {
-    // 임의의 상품 데이터
-    ItemResponse item = new ItemResponse(
-        itemId,
-        "프리미엄 무선 이어폰",
-        "테크스토어",
-        20,
-        89000,
-        "/images/items/no-img.png"
-    );
-    model.addAttribute("item", item);
+    Optional<ItemResponse> item = itemService.getItemDetail(itemId);
+    
+    model.addAttribute("item", item.get());
     return "item-detail";
   }
 }

--- a/src/main/java/com/example/ourPick/controller/ItemController.java
+++ b/src/main/java/com/example/ourPick/controller/ItemController.java
@@ -4,8 +4,11 @@ import com.example.ourPick.dto.ItemRequestRequest;
 import com.example.ourPick.dto.ItemResponse;
 import com.example.ourPick.service.ItemService;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +30,13 @@ public class ItemController {
   public List<ItemResponse> getItems() {
     List<ItemResponse> results = itemService.getItems();
     return results;
+  }
+
+  @GetMapping("/{itemId}")
+  public ResponseEntity<ItemResponse> getItemDetail(@PathVariable int itemId) {
+    Optional<ItemResponse> item = itemService.getItemDetail(itemId);
+    return item.map(ResponseEntity::ok)
+        .orElse(ResponseEntity.notFound().build());
   }
 
 }

--- a/src/main/java/com/example/ourPick/dto/ItemResponse.java
+++ b/src/main/java/com/example/ourPick/dto/ItemResponse.java
@@ -2,28 +2,31 @@ package com.example.ourPick.dto;
 
 import com.example.ourPick.domain.Item;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@EqualsAndHashCode
 public class ItemResponse {
-    private Integer itemId;
-    private String itemName;
-    private String storeName;
-    private int discountRate;
-    private int price;
-    private String mainPhoto;
 
-    public static ItemResponse from(Item item) {
-        return new ItemResponse(
-                item.getItemId(),
-                item.getItemName(),
-                item.getStoreName(),
-                item.getDiscountRate(),
-                item.getPrice(),
-                item.getMainPhoto()
-        );
-    }
+  private Integer itemId;
+  private String itemName;
+  private String storeName;
+  private int discountRate;
+  private int price;
+  private String mainPhoto;
+
+  public static ItemResponse from(Item item) {
+    return new ItemResponse(
+        item.getItemId(),
+        item.getItemName(),
+        item.getStoreName(),
+        item.getDiscountRate(),
+        item.getPrice(),
+        item.getMainPhoto()
+    );
+  }
 }

--- a/src/main/java/com/example/ourPick/service/ItemService.java
+++ b/src/main/java/com/example/ourPick/service/ItemService.java
@@ -4,32 +4,37 @@ import com.example.ourPick.domain.Item;
 import com.example.ourPick.dto.ItemRequestRequest;
 import com.example.ourPick.dto.ItemResponse;
 import com.example.ourPick.repository.ItemRepository;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ItemService {
 
-    private final ItemRepository itemRepository;
+  private final ItemRepository itemRepository;
 
-    public void regItem(ItemRequestRequest item) {
-        Item itemEntity = new Item(
-                item.getItemName(),
-                item.getStoreName(),
-                item.getDiscountRate(),
-                item.getPrice(),
-                item.getMainPhoto()
-                );
-        itemRepository.save(itemEntity);
-    }
+  public void regItem(ItemRequestRequest item) {
+    Item itemEntity = new Item(
+        item.getItemName(),
+        item.getStoreName(),
+        item.getDiscountRate(),
+        item.getPrice(),
+        item.getMainPhoto()
+    );
+    itemRepository.save(itemEntity);
+  }
 
-    public List<ItemResponse> getItems() {
-        final List<Item> items = itemRepository.findAll();
-        return items.stream()
-                .map(ItemResponse::from)
-                .toList();
-    }
+  public List<ItemResponse> getItems() {
+    final List<Item> items = itemRepository.findAll();
+    return items.stream()
+        .map(ItemResponse::from)
+        .toList();
+  }
+
+  public Optional<ItemResponse> getItemDetail(int itemId) {
+    Optional<ItemResponse> item = itemRepository.findById(itemId).map(ItemResponse::from);
+    return item;
+  }
 }

--- a/src/test/java/com/example/ourPick/itemServiceTest.java
+++ b/src/test/java/com/example/ourPick/itemServiceTest.java
@@ -12,6 +12,7 @@ import com.example.ourPick.repository.ItemRepository;
 import com.example.ourPick.service.ItemService;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 public class itemServiceTest {
@@ -62,6 +64,21 @@ public class itemServiceTest {
     Assertions.assertEquals("itemName2", items.get(1).getItemName());
 
     verify(itemRepository, times(1)).findAll();
+  }
+
+  @Test
+  @DisplayName("itemId를 통해서 item을 조회할 수 있다.")
+  void findById() {
+    Item item = new Item("itemName1", "storeName1", 10, 10000, "mainPhoto1");
+    int itemId = 1;
+    ReflectionTestUtils.setField(item, "itemId", itemId);
+
+    when(itemRepository.findById(itemId)).thenReturn(Optional.of(item));
+    Optional<ItemResponse> foundItem = itemService.getItemDetail(itemId);
+    ItemResponse itemResponse = ItemResponse.from(item);
+
+    Assertions.assertTrue(foundItem.isPresent());
+    Assertions.assertEquals(itemResponse, foundItem.get());
   }
 
 }


### PR DESCRIPTION
## #️⃣ Issue_number

> #1

## 📝 Describe

- ItemService에 getItemDetail 메서드 추가 (Optional<ItemResponse> 반환)
- ItemController에 GET /items/{itemId} API 엔드포인트 추가
- HomeController에서 실제 DB 데이터 사용하도록 변경
- ItemResponse에 @EqualsAndHashCode 추가
- 상품 상세 조회 TDD 테스트 추가

### 📸 Screenshots (선택)

>

### 💬 Review requirements(선택)

> 
