### PR TITLE
feat: 상품 검색 API 구현 (FULLTEXT 검색)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,6 +21,20 @@ jobs:
     permissions:
       contents: read
 
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: ${{ secrets.DB_PASSWORD }}
+          MYSQL_DATABASE: our_pick
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17
@@ -38,9 +52,8 @@ jobs:
 
     - name: Build with Gradle Wrapper
       run: ./gradlew build
-
-    - name: Test
-      run: ./gradlew test
+      env:
+        DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
 
     # NOTE: The Gradle Wrapper is the default and recommended way to run Gradle (https://docs.gradle.org/current/userguide/gradle_wrapper.html).
     # If your project does not have the Gradle Wrapper configured, you can use the following configuration to run Gradle with a specified version.

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,20 +21,6 @@ jobs:
     permissions:
       contents: read
 
-    services:
-      mysql:
-        image: mysql:8.0
-        env:
-          MYSQL_ROOT_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          MYSQL_DATABASE: our_pick
-        ports:
-          - 3306:3306
-        options: >-
-          --health-cmd="mysqladmin ping"
-          --health-interval=10s
-          --health-timeout=5s
-          --health-retries=3
-
     steps:
     - uses: actions/checkout@v4
     - name: Set up JDK 17
@@ -47,6 +33,20 @@ jobs:
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+    - name: Start MySQL
+      run: |
+        docker run -d \
+          --name mysql \
+          -e MYSQL_ROOT_PASSWORD=${{ secrets.DB_PASSWORD }} \
+          -e MYSQL_DATABASE=our_pick \
+          -p 3306:3306 \
+          mysql:8.0 \
+          --innodb_ft_min_token_size=2
+        until docker exec mysql mysqladmin ping --silent; do
+          echo "MySQL 준비 중..."
+          sleep 2
+        done
+
     - name: Grant execute permission for Gradlew
       run: chmod +x gradlew
 

--- a/src/main/java/com/example/ourPick/controller/ItemController.java
+++ b/src/main/java/com/example/ourPick/controller/ItemController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -37,6 +38,12 @@ public class ItemController {
     Optional<ItemResponse> item = itemService.getItemDetail(itemId);
     return item.map(ResponseEntity::ok)
         .orElse(ResponseEntity.notFound().build());
+  }
+
+  @GetMapping("/search")
+  public List<ItemResponse> searchItems(
+      @RequestParam(required = false) String keyword) {
+    return itemService.searchItems(keyword);
   }
 
 }

--- a/src/main/java/com/example/ourPick/repository/ItemRepository.java
+++ b/src/main/java/com/example/ourPick/repository/ItemRepository.java
@@ -1,10 +1,15 @@
 package com.example.ourPick.repository;
 
 import com.example.ourPick.domain.Item;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Integer> {
 
+  @Query(value = "SELECT * FROM items WHERE MATCH(item_name, store_name) AGAINST(:searchKeyword IN BOOLEAN MODE)", nativeQuery = true)
+  List<Item> searchItems(@Param("searchKeyword") String searchKeyword);
 }

--- a/src/main/java/com/example/ourPick/service/ItemService.java
+++ b/src/main/java/com/example/ourPick/service/ItemService.java
@@ -4,10 +4,8 @@ import com.example.ourPick.domain.Item;
 import com.example.ourPick.dto.ItemRequestRequest;
 import com.example.ourPick.dto.ItemResponse;
 import com.example.ourPick.repository.ItemRepository;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -45,7 +43,7 @@ public class ItemService {
       return List.of();
     }
 
-    String processedKeyword = processSearchKeyword(keyword);
+    String processedKeyword = StringUtils.processSearchKeyword(keyword);
     if (processedKeyword.isEmpty()) {
       return List.of();
     }
@@ -54,23 +52,5 @@ public class ItemService {
     return items.stream()
         .map(ItemResponse::from)
         .toList();
-  }
-
-  private String processSearchKeyword(String keyword) {
-    String normalized = keyword.trim().replaceAll("\\s+", " ")
-        .replaceAll("[+\\-<>()~*\"']", "");
-
-    if (normalized.isEmpty()) {
-      return "";
-    }
-
-    if (normalized.length() > 100) {
-      normalized = normalized.substring(0, 100);
-    }
-
-    return Arrays.stream(normalized.split("\\s+"))
-        .filter(word -> !word.isEmpty())
-        .map(word -> "+" + word)
-        .collect(Collectors.joining(" "));
   }
 }

--- a/src/main/java/com/example/ourPick/service/StringUtils.java
+++ b/src/main/java/com/example/ourPick/service/StringUtils.java
@@ -1,0 +1,28 @@
+package com.example.ourPick.service;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+public class StringUtils {
+
+  private static final int MAX_KEYWORD_LENGTH = 100;
+
+  public static String processSearchKeyword(String keyword) {
+    String normalized = keyword.trim().replaceAll("\\s+", " ")
+        .replaceAll("[+\\-<>()~*\"']", "");
+
+    if (normalized.isEmpty()) {
+      return "";
+    }
+
+    if (normalized.length() > MAX_KEYWORD_LENGTH) {
+      normalized = normalized.substring(0, MAX_KEYWORD_LENGTH);
+    }
+
+    return Arrays.stream(normalized.split("\\s+"))
+        .filter(word -> !word.isEmpty())
+        .map(word -> "+" + word)
+        .collect(Collectors.joining(" "));
+  }
+}
+

--- a/src/main/java/com/example/ourPick/service/StringUtils.java
+++ b/src/main/java/com/example/ourPick/service/StringUtils.java
@@ -6,10 +6,16 @@ import java.util.stream.Collectors;
 public class StringUtils {
 
   private static final int MAX_KEYWORD_LENGTH = 100;
+  private static final int MIN_WORD_LENGTH = 3;
 
   public static String processSearchKeyword(String keyword) {
-    String normalized = keyword.trim().replaceAll("\\s+", " ")
-        .replaceAll("[+\\-<>()~*\"']", "");
+    if (keyword == null) {
+      return "";
+    }
+
+    String normalized = keyword
+        .trim()
+        .replaceAll("[^0-9A-Za-z가-힣\\s]", "");
 
     if (normalized.isEmpty()) {
       return "";
@@ -19,10 +25,12 @@ public class StringUtils {
       normalized = normalized.substring(0, MAX_KEYWORD_LENGTH);
     }
 
-    return Arrays.stream(normalized.split("\\s+"))
-        .filter(word -> !word.isEmpty())
+    String result = Arrays.stream(normalized.split("\\s+"))
+        .filter(word -> word.length() >= MIN_WORD_LENGTH)
         .map(word -> "+" + word)
         .collect(Collectors.joining(" "));
+
+    return result;
   }
 }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.datasource.url=jdbc:mysql://localhost:3306/our_pick
 
 spring.datasource.username=root
 
-spring.datasource.password=0168
+spring.datasource.password=${DB_PASSWORD}
 
 spring.jpa.show-sql=true
 

--- a/src/test/java/com/example/ourPick/StringUtilsTest.java
+++ b/src/test/java/com/example/ourPick/StringUtilsTest.java
@@ -1,0 +1,110 @@
+package com.example.ourPick;
+
+import com.example.ourPick.service.StringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class StringUtilsTest {
+
+  @Test
+  @DisplayName("단일_단어_검색어를_처리한다")
+  void processSearchKeyword_ShouldProcessSingleWord() {
+    String result = StringUtils.processSearchKeyword("스웨터");
+
+    Assertions.assertEquals("+스웨터", result);
+  }
+
+  @Test
+  @DisplayName("여러_단어_검색어를_처리한다")
+  void processSearchKeyword_ShouldProcessMultipleWords() {
+    String result = StringUtils.processSearchKeyword("스웨터 니트");
+
+    Assertions.assertEquals("+스웨터 +니트", result);
+  }
+
+  @Test
+  @DisplayName("공백이_많은_검색어를_정규화한다")
+  void processSearchKeyword_ShouldNormalizeWhitespace() {
+    String result = StringUtils.processSearchKeyword("  스웨터    니트  ");
+
+    Assertions.assertEquals("+스웨터 +니트", result);
+  }
+
+  @Test
+  @DisplayName("특수문자를_제거한다")
+  void processSearchKeyword_ShouldRemoveSpecialCharacters() {
+    String result = StringUtils.processSearchKeyword("스웨터+니트-가을");
+
+    Assertions.assertEquals("+스웨터 +니트 +가을", result);
+  }
+
+  @Test
+  @DisplayName("모든_BOOLEAN_MODE_특수문자를_제거한다")
+  void processSearchKeyword_ShouldRemoveAllBooleanModeSpecialCharacters() {
+    String result = StringUtils.processSearchKeyword("스웨터+-<>()~*\"'니트");
+
+    Assertions.assertEquals("+스웨터 +니트", result);
+  }
+
+  @Test
+  @DisplayName("검색어_길이가_100자를_초과하면_100자로_제한한다")
+  void processSearchKeyword_ShouldLimitToMaxLength() {
+    String longKeyword = "가".repeat(150);
+    String result = StringUtils.processSearchKeyword(longKeyword);
+
+    Assertions.assertEquals(100, result.replaceAll("\\+", "").replaceAll(" ", "").length());
+    Assertions.assertTrue(result.startsWith("+"));
+  }
+
+  @Test
+  @DisplayName("빈_문자열은_빈_문자열을_반환한다")
+  void processSearchKeyword_ShouldReturnEmptyString_WhenInputIsEmpty() {
+    String result = StringUtils.processSearchKeyword("");
+
+    Assertions.assertEquals("", result);
+  }
+
+  @Test
+  @DisplayName("공백만_있는_문자열은_빈_문자열을_반환한다")
+  void processSearchKeyword_ShouldReturnEmptyString_WhenInputIsOnlyWhitespace() {
+    String result = StringUtils.processSearchKeyword("   ");
+
+    Assertions.assertEquals("", result);
+  }
+
+  @Test
+  @DisplayName("특수문자만_있는_문자열은_빈_문자열을_반환한다")
+  void processSearchKeyword_ShouldReturnEmptyString_WhenInputIsOnlySpecialCharacters() {
+    String result = StringUtils.processSearchKeyword("+-<>()~*\"'");
+
+    Assertions.assertEquals("", result);
+  }
+
+  @Test
+  @DisplayName("연속된_특수문자와_공백을_처리한다")
+  void processSearchKeyword_ShouldHandleConsecutiveSpecialCharactersAndSpaces() {
+    String result = StringUtils.processSearchKeyword("스웨터+++---니트   가을");
+
+    Assertions.assertEquals("+스웨터 +니트 +가을", result);
+  }
+
+  @Test
+  @DisplayName("영문과_숫자가_포함된_검색어를_처리한다")
+  void processSearchKeyword_ShouldHandleEnglishAndNumbers() {
+    String result = StringUtils.processSearchKeyword("sweater 123 니트");
+
+    Assertions.assertEquals("+sweater +123 +니트", result);
+  }
+
+  @Test
+  @DisplayName("100자_정확히_들어가는_경우_정상_처리한다")
+  void processSearchKeyword_ShouldProcessExactly100Characters() {
+    String keyword = "가".repeat(100);
+    String result = StringUtils.processSearchKeyword(keyword);
+
+    Assertions.assertEquals("+" + keyword, result);
+  }
+
+}
+

--- a/src/test/java/com/example/ourPick/StringUtilsTest.java
+++ b/src/test/java/com/example/ourPick/StringUtilsTest.java
@@ -8,98 +8,49 @@ import org.junit.jupiter.api.Test;
 public class StringUtilsTest {
 
   @Test
-  @DisplayName("단일_단어_검색어를_처리한다")
-  void processSearchKeyword_ShouldProcessSingleWord() {
-    String result = StringUtils.processSearchKeyword("스웨터");
-
-    Assertions.assertEquals("+스웨터", result);
+  @DisplayName("null이면 빈 문자열 반환")
+  void returnsEmpty_whenNull() {
+    Assertions.assertEquals("", StringUtils.processSearchKeyword(null));
   }
 
   @Test
-  @DisplayName("여러_단어_검색어를_처리한다")
-  void processSearchKeyword_ShouldProcessMultipleWords() {
-    String result = StringUtils.processSearchKeyword("스웨터 니트");
-
-    Assertions.assertEquals("+스웨터 +니트", result);
+  @DisplayName("공백만 있으면 빈 문자열 반환")
+  void returnsEmpty_whenBlankOnly() {
+    Assertions.assertEquals("", StringUtils.processSearchKeyword(""));
+    Assertions.assertEquals("", StringUtils.processSearchKeyword("   "));
+    Assertions.assertEquals("", StringUtils.processSearchKeyword("\n\t  "));
   }
 
   @Test
-  @DisplayName("공백이_많은_검색어를_정규화한다")
-  void processSearchKeyword_ShouldNormalizeWhitespace() {
-    String result = StringUtils.processSearchKeyword("  스웨터    니트  ");
-
-    Assertions.assertEquals("+스웨터 +니트", result);
+  @DisplayName("특수문자만 있으면 빈 문자열 반환")
+  void returnsEmpty_whenOnlySpecialChars() {
+    Assertions.assertEquals("", StringUtils.processSearchKeyword("!!!@@@###"));
+    Assertions.assertEquals("", StringUtils.processSearchKeyword("!!!   @@@"));
+    Assertions.assertEquals("", StringUtils.processSearchKeyword("+-<>()~*\"'"));
   }
+
 
   @Test
-  @DisplayName("특수문자를_제거한다")
-  void processSearchKeyword_ShouldRemoveSpecialCharacters() {
-    String result = StringUtils.processSearchKeyword("스웨터+니트-가을");
-
-    Assertions.assertEquals("+스웨터 +니트 +가을", result);
+  @DisplayName("3글자 미만 검색어는 제거된다")
+  void filtersOutShortTexts() {
+    Assertions.assertEquals("", StringUtils.processSearchKeyword("a ab 가 가방"));
+    Assertions.assertEquals("+abc", StringUtils.processSearchKeyword("a ab abc"));
+    Assertions.assertEquals("+나이키", StringUtils.processSearchKeyword("나이키 신발"));
   }
 
-  @Test
-  @DisplayName("모든_BOOLEAN_MODE_특수문자를_제거한다")
-  void processSearchKeyword_ShouldRemoveAllBooleanModeSpecialCharacters() {
-    String result = StringUtils.processSearchKeyword("스웨터+-<>()~*\"'니트");
-
-    Assertions.assertEquals("+스웨터 +니트", result);
-  }
 
   @Test
   @DisplayName("검색어_길이가_100자를_초과하면_100자로_제한한다")
-  void processSearchKeyword_ShouldLimitToMaxLength() {
+  void truncatesToMaxLength() {
     String longKeyword = "가".repeat(150);
     String result = StringUtils.processSearchKeyword(longKeyword);
 
-    Assertions.assertEquals(100, result.replaceAll("\\+", "").replaceAll(" ", "").length());
-    Assertions.assertTrue(result.startsWith("+"));
-  }
-
-  @Test
-  @DisplayName("빈_문자열은_빈_문자열을_반환한다")
-  void processSearchKeyword_ShouldReturnEmptyString_WhenInputIsEmpty() {
-    String result = StringUtils.processSearchKeyword("");
-
-    Assertions.assertEquals("", result);
-  }
-
-  @Test
-  @DisplayName("공백만_있는_문자열은_빈_문자열을_반환한다")
-  void processSearchKeyword_ShouldReturnEmptyString_WhenInputIsOnlyWhitespace() {
-    String result = StringUtils.processSearchKeyword("   ");
-
-    Assertions.assertEquals("", result);
-  }
-
-  @Test
-  @DisplayName("특수문자만_있는_문자열은_빈_문자열을_반환한다")
-  void processSearchKeyword_ShouldReturnEmptyString_WhenInputIsOnlySpecialCharacters() {
-    String result = StringUtils.processSearchKeyword("+-<>()~*\"'");
-
-    Assertions.assertEquals("", result);
-  }
-
-  @Test
-  @DisplayName("연속된_특수문자와_공백을_처리한다")
-  void processSearchKeyword_ShouldHandleConsecutiveSpecialCharactersAndSpaces() {
-    String result = StringUtils.processSearchKeyword("스웨터+++---니트   가을");
-
-    Assertions.assertEquals("+스웨터 +니트 +가을", result);
-  }
-
-  @Test
-  @DisplayName("영문과_숫자가_포함된_검색어를_처리한다")
-  void processSearchKeyword_ShouldHandleEnglishAndNumbers() {
-    String result = StringUtils.processSearchKeyword("sweater 123 니트");
-
-    Assertions.assertEquals("+sweater +123 +니트", result);
+    Assertions.assertEquals(101, result.length());
   }
 
   @Test
   @DisplayName("100자_정확히_들어가는_경우_정상_처리한다")
-  void processSearchKeyword_ShouldProcessExactly100Characters() {
+  void doesNotTruncate_whenLengthEqualsMax() {
     String keyword = "가".repeat(100);
     String result = StringUtils.processSearchKeyword(keyword);
 

--- a/src/test/java/com/example/ourPick/itemRepositoryTest.java
+++ b/src/test/java/com/example/ourPick/itemRepositoryTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Sql(scripts = "/sql/create-fulltext-index.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
 class ItemRepositoryTest {
 
   @Autowired

--- a/src/test/java/com/example/ourPick/itemRepositoryTest.java
+++ b/src/test/java/com/example/ourPick/itemRepositoryTest.java
@@ -3,14 +3,15 @@ package com.example.ourPick;
 import com.example.ourPick.domain.Item;
 import com.example.ourPick.repository.ItemRepository;
 import java.util.List;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.jdbc.Sql;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,20 +20,28 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
-@Sql(scripts = "/sql/create-fulltext-index.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class ItemRepositoryTest {
 
   @Autowired
   private ItemRepository itemRepository;
 
-  @BeforeEach
+  @Autowired
+  private JdbcTemplate jdbcTemplate;
+
+  @BeforeAll
   void setUp() {
+    try {
+      jdbcTemplate.execute("ALTER TABLE items DROP INDEX idx_fulltext");
+    } catch (Exception ignored) {}
+    jdbcTemplate.execute("ALTER TABLE items ADD FULLTEXT INDEX idx_fulltext (item_name, store_name)");
+
     itemRepository.save(new Item("아이폰 15", "애플스토어", 10, 10000, "mainPhoto1"));
     itemRepository.save(new Item("갤럭시 S24", "삼성스토어", 20, 20000, "mainPhoto2"));
     itemRepository.save(new Item("아이폰 케이스", "쿠팡", 30, 30000, "mainPhoto3"));
   }
 
-  @AfterEach
+  @AfterAll
   void cleanup() {
     itemRepository.deleteAll();
   }

--- a/src/test/java/com/example/ourPick/itemRepositoryTest.java
+++ b/src/test/java/com/example/ourPick/itemRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.example.ourPick;
+
+import com.example.ourPick.domain.Item;
+import com.example.ourPick.repository.ItemRepository;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class ItemRepositoryTest {
+
+  @Autowired
+  private ItemRepository itemRepository;
+
+  @BeforeEach
+  void setUp() {
+    itemRepository.save(new Item("아이폰 15", "애플스토어", 10, 10000, "mainPhoto1"));
+    itemRepository.save(new Item("갤럭시 S24", "삼성스토어", 20, 20000, "mainPhoto2"));
+    itemRepository.save(new Item("아이폰 케이스", "쿠팡", 30, 30000, "mainPhoto3"));
+  }
+
+  @AfterEach
+  void cleanup() {
+    itemRepository.deleteAll();
+  }
+
+  @Test
+  @DisplayName("아이폰 검색 결과 조회")
+  void searchItems_success() {
+    List<Item> result = itemRepository.searchItems("아이폰");
+
+    assertThat(result).hasSize(2)
+        .extracting("itemName")
+        .containsExactlyInAnyOrder("아이폰 15", "아이폰 케이스");
+  }
+
+  @Test
+  @DisplayName("없는 키워드 검색 시 빈 리스트 반환")
+  void searchItems_noResult() {
+    List<Item> result = itemRepository.searchItems("노트북");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("상점명으로 검색")
+  void searchItems_byStoreName() {
+    List<Item> result = itemRepository.searchItems("애플스토어");
+
+    assertThat(result).hasSize(1)
+        .extracting("itemName")
+        .containsExactly("아이폰 15");
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,7 +1,7 @@
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/our_pick?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
 spring.datasource.username=root
-spring.datasource.password=0168
+spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,10 +1,8 @@
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.url=jdbc:h2:mem:our_pick_test;MODE=MySQL
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url=jdbc:mysql://localhost:3306/our_pick?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
+spring.datasource.username=root
+spring.datasource.password=0168
+spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
+spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect

--- a/src/test/resources/sql/create-fulltext-index.sql
+++ b/src/test/resources/sql/create-fulltext-index.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_fulltext ON items;
+ALTER TABLE items ADD FULLTEXT INDEX idx_fulltext (item_name, store_name);

--- a/src/test/resources/sql/create-fulltext-index.sql
+++ b/src/test/resources/sql/create-fulltext-index.sql
@@ -1,2 +1,1 @@
-DROP INDEX IF EXISTS idx_fulltext ON items;
 ALTER TABLE items ADD FULLTEXT INDEX idx_fulltext (item_name, store_name);


### PR DESCRIPTION
## #️⃣ Issue_number

> #2


## 📝 Describe

> feat: 상품 검색 API 구현 (FULLTEXT 검색)

- Repository에 FULLTEXT 검색 쿼리 추가
    * MySQL MATCH ... AGAINST를 사용한 BOOLEAN MODE 검색
    * item_name과 store_name 필드에서 검색 지원

- Service에 검색어 전처리 로직 구현
    * NULL/빈 문자열 검증
    * 공백 정규화 (앞뒤 공백 제거, 연속 공백 통합)
    * BOOLEAN MODE 특수문자 제거 (+, -, <, >, (, ), ~, *, ", ')
    * 여러 단어 검색 지원 (각 단어에 + 적용하여 필수 단어로 처리)
    * 검색어 길이 제한 (100자)
    * processSearchKeyword 메서드 분리로 가독성 향상

- Controller에 검색 엔드포인트 추가
    * GET /items/search?keyword={검색어}

### 📸 Screenshots (선택)

>

### 💬 Review requirements(선택)

> 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces item search backed by MySQL FULLTEXT with input preprocessing for safer, more precise queries.
> 
> - Adds `GET /items/search?keyword=` in `ItemController` returning `List<ItemResponse>`
> - Implements `ItemService.searchItems` with null/blank guards, keyword processing, and mapping of repository results
> - Adds `ItemRepository.searchItems` native query using `MATCH(item_name, store_name) AGAINST(... IN BOOLEAN MODE)`
> - New `StringUtils.processSearchKeyword` for normalization: trim, remove special chars, min word length (3), prepend `+`, max length 100
> - Unit tests in `StringUtilsTest` covering null/blank, special chars, short-word filtering, and length truncation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9da5e28ab1382e8aecd880a8e95d39147b4ff302. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->